### PR TITLE
#-: checking full input value

### DIFF
--- a/src/lib/ngx-mask-input.directive.ts
+++ b/src/lib/ngx-mask-input.directive.ts
@@ -45,7 +45,7 @@ export class NgxMaskInputDirective {
           }
         }
 
-        value = String.fromCharCode(pressedKey);
+        value = $input.value + String.fromCharCode(pressedKey);
         regex = new RegExp(this.mask);
         break;
 


### PR DESCRIPTION
@zgabievi  I noticed that the mask does not work for the entire input value, but only for one character, which is not very convenient. this can be replaced with a regular expression of the type: `^[1-9][0-9]*$` It will be impossible to enter values like example `10, 100, ...`, it is impossible to put `0`, although the regular expression should work for these numbers. I have added a small fix. I will be glad to hear your opinion on this.

P.S.: I apologize for my English ^_^
